### PR TITLE
Speed boost in bitmap drawing

### DIFF
--- a/libraries/Gamebuino/Display.cpp
+++ b/libraries/Gamebuino/Display.cpp
@@ -517,14 +517,16 @@ void Display::fillTriangle(int8_t x0, int8_t y0,
 }
 
 void Display::drawBitmap(int8_t x, int8_t y, const uint8_t *bitmap) {
-	int8_t w = pgm_read_byte(bitmap);
-	int8_t h = pgm_read_byte(bitmap + 1);
+	uint8_t w = pgm_read_byte(bitmap);
+	uint8_t h = pgm_read_byte(bitmap + 1);
 	bitmap = bitmap + 2; //add an offset to the pointer to start after the width and height
 #if (ENABLE_BITMAPS > 0)
-    int8_t i, j, byteWidth = (w + 7) / 8;
-    for (j = 0; j < h; j++) {
-        for (i = 0; i < w; i++) {
-            if (pgm_read_byte(bitmap + j * byteWidth + i / 8) & (B10000000 >> (i % 8))) {
+    int8_t i, j, byteNum, bitNum, byteWidth = (w + 7) >> 3;
+    for (i = 0; i < w; i++) {
+        byteNum = i / 8;
+        bitNum = i % 8;
+        for (j = 0; j < h; j++) {
+            if (pgm_read_byte(bitmap + j * byteWidth + byteNum) & (B10000000 >> bitNum)) {
                 drawPixel(x + i, y + j);
             }
         }
@@ -535,7 +537,7 @@ void Display::drawBitmap(int8_t x, int8_t y, const uint8_t *bitmap) {
 }
 
 boolean Display::getBitmapPixel(const uint8_t* bitmap, uint8_t x, uint8_t y){
-  return pgm_read_byte(bitmap+2 + y * ((pgm_read_byte(bitmap)+7)/8) + x / 8) & (B10000000 >> (x % 8));
+  return pgm_read_byte(bitmap+2 + y * ((pgm_read_byte(bitmap)+7)/8) + (x >> 3)) & (B10000000 >> (x % 8));
 }
 
 void Display::drawBitmap(int8_t x, int8_t y, const uint8_t *bitmap,
@@ -544,19 +546,21 @@ void Display::drawBitmap(int8_t x, int8_t y, const uint8_t *bitmap,
 		drawBitmap(x,y,bitmap); //use the faster algorithm
 		return;
 	}
-	int8_t w = pgm_read_byte(bitmap);
-	int8_t h = pgm_read_byte(bitmap + 1);
+	uint8_t w = pgm_read_byte(bitmap);
+	uint8_t h = pgm_read_byte(bitmap + 1);
 	bitmap = bitmap + 2; //add an offset to the pointer to start after the width and height
 #if (ENABLE_BITMAPS > 0)
     int8_t i, j, //coordinates in the raw bitmap
             k, l, //coordinates in the rotated/flipped bitmap
-            byteWidth = (w + 7) / 8;
+            byteNum, bitNum, byteWidth = (w + 7) >> 3;
 
     rotation %= 4;
 
-    for (j = 0; j < h; j++) {
-        for (i = 0; i < w; i++) {
-            if (pgm_read_byte(bitmap + j * byteWidth + i / 8) & (B10000000 >> (i % 8))) {
+    for (i = 0; i < w; i++) {
+        byteNum = i / 8;
+        bitNum = i % 8;
+        for (j = 0; j < h; j++) {
+            if (pgm_read_byte(bitmap + j * byteWidth + byteNum) & (B10000000 >> bitNum)) {
                 switch (rotation) {
                     case NOROT: //no rotation
                         k = i;


### PR DESCRIPTION
See http://gamebuino.com/forum/viewtopic.php?f=13&t=2922&p=7719#p7719 for notes on the speed boost.

Went from 110 to 92 CPU load using this sketch, which is a 16% speed boost.

````
#include <Gamebuino.h>
#include <SPI.h>
extern const byte font3x5[];
const byte tile[] PROGMEM = {8,6,0xFC,0x24,0xFC,0x90,0xFC,0x48,};
Gamebuino gb;


void setup() {
    gb.begin();
}
   
void loop() {
  if(gb.update()){
    gb.display.setFont(font3x5);
    gb.display.print(F("CPU: "));
    gb.display.println(gb.getCpuLoad());
    
    for (int i = 0; i < LCDWIDTH; i += 6) {
      for (int j = 5; j < LCDHEIGHT; j += 6) {
        gb.display.drawBitmap(i, j, tile, 0, 0);
      }
    }
  }
} 
````

http://i.imgur.com/FKkkEvV.jpg to  http://i.imgur.com/zMPcuV7.jpg 