### PR TITLE
Remove the TIMER1 if there is no sound channel enabled.

### DIFF
--- a/libraries/Gamebuino/Sound.cpp
+++ b/libraries/Gamebuino/Sound.cpp
@@ -452,11 +452,12 @@ void Sound::setChannelHalfPeriod(uint8_t channel, uint8_t halfPeriod) {
 #endif
 }
 
-ISR(TIMER1_COMPA_vect){ // timer compare interrupt service routine
 #if(NUM_CHANNELS > 0)
+ISR(TIMER1_COMPA_vect){ // timer compare interrupt service routine
 	Sound::generateOutput();
-#endif
 }
+#endif
+
 
 void Sound::generateOutput() {
 #if(NUM_CHANNELS > 0)


### PR DESCRIPTION
I think the TIMER1 shouldn't be allocated if the user choose to disable the sound. 