### PR TITLE
Remove leading space from keywords.txt identifier token

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -60,32 +60,32 @@ BTN_DOWN 	LITERAL1
 BTN_LEFT 	LITERAL1
 
 ////////////////////////sound
-playTrack	 KEYWORD1
-updateTrack	 KEYWORD1
-stopTrack	 KEYWORD1
-changePatternSet	 KEYWORD1
-boolean trackIsPlaying	 KEYWORD1
+playTrack	KEYWORD1
+updateTrack	KEYWORD1
+stopTrack	KEYWORD1
+changePatternSet	KEYWORD1
+boolean trackIsPlaying	KEYWORD1
 
-playPattern	 KEYWORD1
-changeInstrumentSet	 KEYWORD1
-updatePattern	 KEYWORD1
-setPatternLooping	 KEYWORD1
-stopPattern	 KEYWORD1
-patternIsPlaying	 KEYWORD1
+playPattern	KEYWORD1
+changeInstrumentSet	KEYWORD1
+updatePattern	KEYWORD1
+setPatternLooping	KEYWORD1
+stopPattern	KEYWORD1
+patternIsPlaying	KEYWORD1
 
-command	 KEYWORD1
-playNote	 KEYWORD1
-updateNote	 KEYWORD1
-stopNote	 KEYWORD1
+command	KEYWORD1
+playNote	KEYWORD1
+updateNote	KEYWORD1
+stopNote	KEYWORD1
 
-setVolume	 KEYWORD1
-getVolume	 KEYWORD1
+setVolume	KEYWORD1
+getVolume	KEYWORD1
 
-playOK	 KEYWORD1
-playCancel	 KEYWORD1
-playTick	 KEYWORD1
+playOK	KEYWORD1
+playCancel	KEYWORD1
+playTick	KEYWORD1
 
-prescaler	 KEYWORD1
+prescaler	KEYWORD1
 
 ////////////////////////battery
 voltage	KEYWORD1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords